### PR TITLE
Fix Issue 2: add Typescript example to the showcase 

### DIFF
--- a/03_typescript/.gitignore
+++ b/03_typescript/.gitignore
@@ -1,0 +1,2 @@
+dist
+test/test.mjs

--- a/03_typescript/src/database/01_todos.sql
+++ b/03_typescript/src/database/01_todos.sql
@@ -1,0 +1,13 @@
+-- liquibase formatted sql
+-- changeset martin-bach-oracle:1
+
+create table todos (
+    id number generated always as identity
+    constraint pk_todos primary key,
+    priority varchar2(10) not null,
+    constraint c_todos_priority check (priority in ('low', 'medium', 'high')),
+    name varchar2(100),
+    created date default sysdate not null,
+    due_date date,
+    done boolean default false not null
+);

--- a/03_typescript/src/database/02_todos_index.sql
+++ b/03_typescript/src/database/02_todos_index.sql
@@ -1,0 +1,4 @@
+-- liquibase formatted sql
+-- changeset martin-bach-oracle:2
+
+create index i_todos$sec1 on todos (name);

--- a/03_typescript/src/database/03_call_specifications.sql
+++ b/03_typescript/src/database/03_call_specifications.sql
@@ -1,0 +1,18 @@
+-- liquibase formatted sql
+-- changeset martin-bach-oracle:3 endDelimiter:/ runAlways:true
+
+create or replace package todos_package as
+
+    function new_todo(todo json) return number
+        as mle module todos_module signature 'newTodo';
+    
+    function get_todo(id number) return JSON
+        as mle module todos_module signature 'getTodo';
+    
+    function update_todo(id number, todo json) return boolean
+        as mle module todos_module signature 'updateTodo';
+    
+    procedure delete_todo(id number)
+        as mle module todos_module signature 'deleteTodo';
+end todos_package;
+/

--- a/03_typescript/src/database/03_call_specifications.sql
+++ b/03_typescript/src/database/03_call_specifications.sql
@@ -12,7 +12,7 @@ create or replace package todos_package as
     function update_todo(id number, todo json) return boolean
         as mle module todos_module signature 'updateTodo';
     
-    procedure delete_todo(id number)
+    function delete_todo(id number) return boolean
         as mle module todos_module signature 'deleteTodo';
 end todos_package;
 /

--- a/03_typescript/src/database/controller.xml
+++ b/03_typescript/src/database/controller.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<databaseChangeLog
+  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+  <include file="01_todos.sql"/> 
+  <include file="02_todos_index.sql"/> 
+  <include file="03_call_specifications.sql"/> 
+</databaseChangeLog> 

--- a/03_typescript/src/typescript/todos.ts
+++ b/03_typescript/src/typescript/todos.ts
@@ -1,0 +1,214 @@
+/**
+ * @fileoverview a short Typescript demo demonstrating how to create, edit,
+ * drop and update Todo items stored in the database. This file must be
+ * transpiled using utils/deploy.sh before it can be used with the database.
+ *
+ * The code is sufficiently small and compact and doesn't need to be spread
+ * out into multiple files.
+ */
+
+export enum Priority {
+	low = "low",
+	medium = "medium",
+	high = "high",
+}
+
+export interface TodoItem {
+	priority: Priority;
+	name: string;
+	created: Date;
+	dueDate: Date;
+	done: boolean;
+}
+
+/**
+ * Creates a new Todo item in the database.
+ *
+ * @param {TodoItem} todo - The Todo item to be created.
+ * @returns {number} The ID of the newly created Todo item.
+ * @throws {Error} If the insertion fails for any reason or a generic error occurs
+ */
+export function newTodo(todo: TodoItem): number {
+	if (typeof todo !== "object") {
+		throw new Error("you must pass a valid todo item to this function");
+	}
+
+	const result = session.execute(
+		`insert into todos (
+            priority,
+            name,
+            created,
+            due_date,
+            done
+        ) values (
+            :priority,
+            :name,
+            :created,
+            :due_date,
+            :done
+        )
+        returning id into :id`,
+		{
+			priority: {
+				type: oracledb.DB_TYPE_VARCHAR,
+				dir: oracledb.BIND_IN,
+				val: todo.priority,
+			},
+			name: {
+				type: oracledb.DB_TYPE_VARCHAR,
+				dir: oracledb.BIND_IN,
+				val: todo.name,
+			},
+			created: {
+				type: oracledb.DB_TYPE_DATE,
+				dir: oracledb.BIND_IN,
+				val: new Date(todo.created),
+			},
+			due_date: {
+				type: oracledb.DB_TYPE_DATE,
+				dir: oracledb.BIND_IN,
+				val: new Date(todo.dueDate),
+			},
+			done: {
+				type: oracledb.DB_TYPE_BOOLEAN,
+				dir: oracledb.BIND_IN,
+				val: todo.done,
+			},
+			id: {
+				type: oracledb.NUMBER,
+				dir: oracledb.BIND_OUT,
+			},
+		},
+	);
+
+	if (result.rowsAffected !== 1) {
+		throw new Error("Failed to insert a new Todo item for an unknown reason");
+	}
+
+	// return the automatically generated ID
+	return result.outBinds.id[0];
+}
+
+export function getTodo(id: number): TodoItem {
+	if (typeof id !== "number") {
+		throw new Error("you must pass a valid ID to this function");
+	}
+
+	// get the details of a newly created Todo item
+	const result = session.execute(
+		`select 
+			id,
+			priority,
+			name,
+			created,
+			due_date,
+			done
+		from
+			todos
+		where
+			id = :id`,
+		[id],
+	);
+
+	//
+	if (result.rows?.length !== 1) {
+		throw new Error(`there is no Todo item with id ${id} in the database`);
+	}
+
+	const todoItem: TodoItem = {
+		priority: result.rows[0].PRIORITY,
+		name: result.rows[0].NAME,
+		created: result.rows[0].CREATED,
+		dueDate: result.rows[0].DUE_DATE,
+		done: result.rows[0].DONE,
+	};
+
+	return todoItem;
+}
+
+/**
+ * Updates an existing Todo item.
+ *
+ * @param {number} id - the todo item's primary key
+ * @param {TodoItem} todo - details about the todo item
+ * @throws {Error} If parameters aren't passed properly, the todo item ID does not exist or a generic error occurs
+ * @returns {boolean} depending on the successful outcome
+ */
+export function updateTodo(id: number, todo: TodoItem): boolean {
+	if (Number.isNaN(id) || typeof todo !== "object") {
+		throw new Error("please pass a valid ID and/or todo item to this function");
+	}
+
+	const result = session.execute(
+		`update todos set
+            priority = :priority,
+            name = :name,
+            created = :created,
+            due_date = :due_date,
+            done = :done
+         where id = :id`,
+		{
+			priority: {
+				type: oracledb.DB_TYPE_VARCHAR,
+				dir: oracledb.BIND_IN,
+				val: todo.priority,
+			},
+			name: {
+				type: oracledb.DB_TYPE_VARCHAR,
+				dir: oracledb.BIND_IN,
+				val: todo.name,
+			},
+			created: {
+				type: oracledb.DB_TYPE_DATE,
+				dir: oracledb.BIND_IN,
+				val: new Date(todo.created),
+			},
+			due_date: {
+				type: oracledb.DB_TYPE_DATE,
+				dir: oracledb.BIND_IN,
+				val: new Date(todo.dueDate),
+			},
+			done: {
+				type: oracledb.DB_TYPE_BOOLEAN,
+				dir: oracledb.BIND_IN,
+				val: todo.done,
+			},
+			id: {
+				type: oracledb.NUMBER,
+				dir: oracledb.BIND_IN,
+				val: id,
+			},
+		},
+	);
+
+	if (result.rowsAffected !== 1) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Deletes an existing Todo item.
+ *
+ * @param {number} id - the todo item's primary key
+ * @throws {Error} If the todo item ID does not exist or a generic error occurs
+ */
+export function deleteTodo(id: number) {
+	if (Number.isNaN(id)) {
+		throw new Error("please provide a valid ID to this function");
+	}
+	const result = session.execute("delete todo where id = :id", {
+		id: {
+			dir: oracledb.BIND_IN,
+			type: oracledb.DB_TYPE_NUMBER,
+			val: id,
+		},
+	});
+
+	if (result.rowsAffected !== 1) {
+		throw new Error(
+			`todo item with id ${id} does not exist and cannot be deleted`,
+		);
+	}
+}

--- a/03_typescript/test/todos.test.ts
+++ b/03_typescript/test/todos.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test, beforeAll, afterAll } from "vitest";
+import * as t from "../src/typescript/todos";
+import oracledb from "oracledb";
+
+// the database connection. Initialised during the call to beforeAll()
+// there's no Typescript type for the connection AFAIK
+let connection;
+
+// the primary key of the todo item created, updated, and eventually deleted
+let id: number;
+
+/**
+ * initialise the database connection before starting any tests.
+ *
+ * Requires adding the connection to GlobalThis for the Typescript
+ * code to work with node.js
+ *
+ * DO NOT HARD CODE credentials in production applications. This
+ * is acceptable ONLY in _this_ particular playground/showcase
+ * environment
+ */
+beforeAll(async () => {
+	connection = await oracledb.getConnection({
+		user: "demouser",
+		password: "demouser",
+		connectionString: "localhost/freepdb1",
+	});
+});
+
+describe("todo unit tests", () => {
+	/**
+	 * Start the test series by creating a new Todo item
+	 */
+	test("add a new todo item", async () => {
+		// use the type definition as per src/typescript/test.ts
+		// and make use of Typescript
+		const todo: t.TodoItem = {
+			name: "enter a todo item via a unit test",
+			priority: t.Priority.low,
+			created: new Date("2025-06-06T12:00:00.000Z"),
+			dueDate: new Date("2025-06-12T14:00:00.000Z"),
+			done: false,
+		};
+
+		// invoke the PL/SQL call specification to create a new
+		// todo item
+		const result = await connection.execute(
+			`declare
+                id number;
+            begin
+                :id := todos_package.new_todo(:todo);
+            end;`,
+			{
+				id: {
+					type: oracledb.NUMBER,
+					dir: oracledb.BIND_OUT,
+				},
+				todo: {
+					val: todo,
+					dir: oracledb.BIND_IN,
+					type: oracledb.DB_TYPE_JSON,
+				},
+			},
+		);
+
+		id = result.outBinds.id;
+		expect(id).toBeGreaterThan(0);
+	});
+
+	/**
+	 * Get details about the previously created todo item
+	 */
+	test("retrieve the todo item's details", async () => {
+		// invoke the PL/SQL call specification to retrieve
+		// the previously created todo item
+		const result = await connection.execute(
+			`select
+				todos_package.get_todo(:id) as todoItem`,
+			[id],
+			{
+				outFormat: oracledb.OUT_FORMAT_OBJECT,
+			},
+		);
+
+		expect(result.rows.length).toBe(1);
+	});
+
+	/**
+	 * Update the Todo Item
+	 */
+	test("update the todo item's details", async () => {
+		let result = await connection.execute(
+			`select
+				todos_package.get_todo(:id) as todoItem`,
+			[id],
+			{
+				outFormat: oracledb.OUT_FORMAT_OBJECT,
+			},
+		);
+
+		// bump the priority and set the status to DONE
+		const todo: t.TodoItem = {
+			priority: t.Priority.high,
+			name: result.rows[0].TODOITEM.name,
+			created: result.rows[0].TODOITEM.created,
+			dueDate: result.rows[0].TODOITEM.dueDate,
+			done: true,
+		};
+
+		result = await connection.execute(
+			"declare l_status boolean; begin :l_status := todos_package.update_todo(id => :id, todo => :todo); end;",
+			{
+				l_status: {
+					dir: oracledb.BIND_OUT,
+					type: oracledb.DB_TYPE_BOOLEAN
+				},
+				id: {
+					dir: oracledb.BIND_IN,
+					value: id
+				}, todo: {
+					dir: oracledb.BIND_IN,
+					value: todo,
+					type: oracledb.DB_TYPE_JSON
+				}
+			}
+		);
+
+		expect(result.outBinds.l_status).toBeTruthy();
+	});
+});
+
+afterAll(async () => {
+	await connection.close();
+});

--- a/03_typescript/tsconfig.json
+++ b/03_typescript/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"rootDir": "src/typescript",
+		"outDir": "dist/",
+		"noEmitOnError": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": false,
+		"moduleResolution": "bundler",
+		"lib": ["ES6", "ES2017", "ES2021"],
+	},
+	"exclude": ["test"]
+}

--- a/03_typescript/utils/deploy.sh
+++ b/03_typescript/utils/deploy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/bash
+
+#
+# simulate a CI/CD pipeline by transpiling Typescript to JavaScript
+# and loading it into the database.
+
+set -euxo pipefail
+
+# make sure we're in the correct directory or else the relative paths
+# won't work an this script fails
+[[ $(basename "$(pwd)") != 03_typescript ]] && {
+    echo "ERR: make sure you are in 03_typescript before invoking ${0}"
+    exit 1
+}
+
+# simulate the CI pipeline and create the resulting JavaScript
+# file in the dist/ directory
+npx biome format --verbose src/typescript --write && \
+npx biome lint --verbose src/typescript && \
+npx tsc
+
+# Now connect to the database and deploy the transpiled module and database
+# schema objects
+# connection details are typically stored in a cloud vault. For the sake of this
+# showcase/demo it is fine to hard-code values. DO NOT DO THIS YOURSELF
+# Note: you must ensure that SQLcl is in your path
+sql demouser/demouser@localhost/freepdb1 <<-EOF
+
+whenever sqlerror exit 1
+
+-- create the necessary tables ...
+lb update -search-path src/database -changelog-file controller.xml 
+
+-- ... and the typescript code
+mle create-module -filename dist/todos.js -module-name todos_module -replace
+
+-- ensure there are no invalid objects
+begin
+    dbms_utility.compile_schema(user);
+end;
+/
+
+prompt checking for invalid objects past deployment ...
+select
+    object_name,
+    object_type
+from
+    user_objects
+where
+    status != 'VALID';
+
+EOF

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false,
+		"ignore": []
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"organizeImports": {
+		"enabled": true
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "double"
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
 			"devDependencies": {
 				"@biomejs/biome": "1.9.4",
 				"esbuild": "0.25.5",
-				"typescript": "^5.8.3"
+				"oracledb": "^6.8.0",
+				"typescript": "^5.8.3",
+				"vitest": "^3.2.2"
 			}
 		},
 		"node_modules/@biomejs/biome": {
@@ -602,10 +604,517 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@rollup/rollup-android-arm-eabi": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz",
+			"integrity": "sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-android-arm64": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.41.1.tgz",
+			"integrity": "sha512-DXdQe1BJ6TK47ukAoZLehRHhfKnKg9BjnQYUu9gzhI8Mwa1d2fzxA1aw2JixHVl403bwp1+/o/NhhHtxWJBgEA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-arm64": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.1.tgz",
+			"integrity": "sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-darwin-x64": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.41.1.tgz",
+			"integrity": "sha512-egpJACny8QOdHNNMZKf8xY0Is6gIMz+tuqXlusxquWu3F833DcMwmGM7WlvCO9sB3OsPjdC4U0wHw5FabzCGZg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-arm64": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.41.1.tgz",
+			"integrity": "sha512-DBVMZH5vbjgRk3r0OzgjS38z+atlupJ7xfKIDJdZZL6sM6wjfDNo64aowcLPKIx7LMQi8vybB56uh1Ftck/Atg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-freebsd-x64": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.41.1.tgz",
+			"integrity": "sha512-3FkydeohozEskBxNWEIbPfOE0aqQgB6ttTkJ159uWOFn42VLyfAiyD9UK5mhu+ItWzft60DycIN1Xdgiy8o/SA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.41.1.tgz",
+			"integrity": "sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.41.1.tgz",
+			"integrity": "sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-gnu": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.41.1.tgz",
+			"integrity": "sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm64-musl": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.41.1.tgz",
+			"integrity": "sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.41.1.tgz",
+			"integrity": "sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.41.1.tgz",
+			"integrity": "sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.41.1.tgz",
+			"integrity": "sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-riscv64-musl": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.41.1.tgz",
+			"integrity": "sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.41.1.tgz",
+			"integrity": "sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-gnu": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.1.tgz",
+			"integrity": "sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-x64-musl": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.41.1.tgz",
+			"integrity": "sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-arm64-msvc": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.41.1.tgz",
+			"integrity": "sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-ia32-msvc": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.41.1.tgz",
+			"integrity": "sha512-+psFT9+pIh2iuGsxFYYa/LhS5MFKmuivRsx9iPJWNSGbh2XVEjk90fmpUEjCnILPEPJnikAU6SFDiEUyOv90Pg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@rollup/rollup-win32-x64-msvc": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.1.tgz",
+			"integrity": "sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@types/chai": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+			"integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/deep-eql": "*"
+			}
+		},
+		"node_modules/@types/deep-eql": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/mle-js": {
 			"version": "23.8.0",
 			"resolved": "git+ssh://git@github.com/oracle-samples/mle-modules.git#b95b73f66b4a8f83cdd99aa8c8bbc4cbf1c275d2",
 			"license": "UPL-1.0"
+		},
+		"node_modules/@vitest/expect": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.2.tgz",
+			"integrity": "sha512-ipHw0z669vEMjzz3xQE8nJX1s0rQIb7oEl4jjl35qWTwm/KIHERIg/p/zORrjAaZKXfsv7IybcNGHwhOOAPMwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/spy": "3.2.2",
+				"@vitest/utils": "3.2.2",
+				"chai": "^5.2.0",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/mocker": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.2.tgz",
+			"integrity": "sha512-jKojcaRyIYpDEf+s7/dD3LJt53c0dPfp5zCPXz9H/kcGrSlovU/t1yEaNzM9oFME3dcd4ULwRI/x0Po1Zf+LTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/spy": "3.2.2",
+				"estree-walker": "^3.0.3",
+				"magic-string": "^0.30.17"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"msw": "^2.4.9",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"peerDependenciesMeta": {
+				"msw": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@vitest/pretty-format": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.2.tgz",
+			"integrity": "sha512-FY4o4U1UDhO9KMd2Wee5vumwcaHw7Vg4V7yR4Oq6uK34nhEJOmdRYrk3ClburPRUA09lXD/oXWZ8y/Sdma0aUQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/runner": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.2.tgz",
+			"integrity": "sha512-GYcHcaS3ejGRZYed2GAkvsjBeXIEerDKdX3orQrBJqLRiea4NSS9qvn9Nxmuy1IwIB+EjFOaxXnX79l8HFaBwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/utils": "3.2.2",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/snapshot": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.2.tgz",
+			"integrity": "sha512-aMEI2XFlR1aNECbBs5C5IZopfi5Lb8QJZGGpzS8ZUHML5La5wCbrbhLOVSME68qwpT05ROEEOAZPRXFpxZV2wA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.2",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/spy": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.2.tgz",
+			"integrity": "sha512-6Utxlx3o7pcTxvp0u8kUiXtRFScMrUg28KjB3R2hon7w4YqOFAEA9QwzPVVS1QNL3smo4xRNOpNZClRVfpMcYg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyspy": "^4.0.3"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.2.tgz",
+			"integrity": "sha512-qJYMllrWpF/OYfWHP32T31QCaLa3BAzT/n/8mNGhPdVcjY+JYazQFO1nsJvXU12Kp1xMpNY4AGuljPTNjQve6A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@vitest/pretty-format": "3.2.2",
+				"loupe": "^3.1.3",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/assertion-error": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/cac": {
+			"version": "6.7.14",
+			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+			"integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/chai": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+			"integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"assertion-error": "^2.0.1",
+				"check-error": "^2.1.1",
+				"deep-eql": "^5.0.1",
+				"loupe": "^3.1.0",
+				"pathval": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/check-error": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+			"integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-eql": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+			"integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/esbuild": {
 			"version": "0.25.5",
@@ -648,6 +1157,315 @@
 				"@esbuild/win32-x64": "0.25.5"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/expect-type": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+			"integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/fdir": {
+			"version": "6.4.5",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+			"integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/loupe": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+			"integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.17",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/oracledb": {
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.8.0.tgz",
+			"integrity": "sha512-A4ds4n4xtjPTzk1gwrHWuMeWsEcrScF0GFgVebGrhNpHSAzn6eDwMKcSbakZODKfFcI099iqhmqWsgko8D+7Ww==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "(Apache-2.0 OR UPL-1.0)",
+			"engines": {
+				"node": ">=14.6"
+			}
+		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/pathval": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+			"integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14.16"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.4",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
+			"integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.11",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "4.41.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.1.tgz",
+			"integrity": "sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "1.0.7"
+			},
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=18.0.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-android-arm-eabi": "4.41.1",
+				"@rollup/rollup-android-arm64": "4.41.1",
+				"@rollup/rollup-darwin-arm64": "4.41.1",
+				"@rollup/rollup-darwin-x64": "4.41.1",
+				"@rollup/rollup-freebsd-arm64": "4.41.1",
+				"@rollup/rollup-freebsd-x64": "4.41.1",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.41.1",
+				"@rollup/rollup-linux-arm-musleabihf": "4.41.1",
+				"@rollup/rollup-linux-arm64-gnu": "4.41.1",
+				"@rollup/rollup-linux-arm64-musl": "4.41.1",
+				"@rollup/rollup-linux-loongarch64-gnu": "4.41.1",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.41.1",
+				"@rollup/rollup-linux-riscv64-gnu": "4.41.1",
+				"@rollup/rollup-linux-riscv64-musl": "4.41.1",
+				"@rollup/rollup-linux-s390x-gnu": "4.41.1",
+				"@rollup/rollup-linux-x64-gnu": "4.41.1",
+				"@rollup/rollup-linux-x64-musl": "4.41.1",
+				"@rollup/rollup-win32-arm64-msvc": "4.41.1",
+				"@rollup/rollup-win32-ia32-msvc": "4.41.1",
+				"@rollup/rollup-win32-x64-msvc": "4.41.1",
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/rollup/node_modules/@types/estree": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
+			"integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/siginfo": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/stackback": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/std-env": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+			"integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinybench": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+			"integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyexec": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+			"integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.14",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+			"integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.4.4",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinypool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
+			"integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			}
+		},
+		"node_modules/tinyrainbow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+			"integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tinyspy": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+			"integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -660,6 +1478,194 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/vite": {
+			"version": "6.3.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+			"integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "^0.25.0",
+				"fdir": "^6.4.4",
+				"picomatch": "^4.0.2",
+				"postcss": "^8.5.3",
+				"rollup": "^4.34.9",
+				"tinyglobby": "^0.2.13"
+			},
+			"bin": {
+				"vite": "bin/vite.js"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/vitejs/vite?sponsor=1"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			},
+			"peerDependencies": {
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"jiti": ">=1.21.0",
+				"less": "*",
+				"lightningcss": "^1.21.0",
+				"sass": "*",
+				"sass-embedded": "*",
+				"stylus": "*",
+				"sugarss": "*",
+				"terser": "^5.16.0",
+				"tsx": "^4.8.1",
+				"yaml": "^2.4.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				},
+				"jiti": {
+					"optional": true
+				},
+				"less": {
+					"optional": true
+				},
+				"lightningcss": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"sass-embedded": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				},
+				"sugarss": {
+					"optional": true
+				},
+				"terser": {
+					"optional": true
+				},
+				"tsx": {
+					"optional": true
+				},
+				"yaml": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/vite-node": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.2.tgz",
+			"integrity": "sha512-Xj/jovjZvDXOq2FgLXu8NsY4uHUMWtzVmMC2LkCu9HWdr9Qu1Is5sanX3Z4jOFKdohfaWDnEJWp9pRP0vVpAcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cac": "^6.7.14",
+				"debug": "^4.4.1",
+				"es-module-lexer": "^1.7.0",
+				"pathe": "^2.0.3",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+			},
+			"bin": {
+				"vite-node": "vite-node.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/vitest": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.2.tgz",
+			"integrity": "sha512-fyNn/Rp016Bt5qvY0OQvIUCwW2vnaEBLxP42PmKbNIoasSYjML+8xyeADOPvBe+Xfl/ubIw4og7Lt9jflRsCNw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/chai": "^5.2.2",
+				"@vitest/expect": "3.2.2",
+				"@vitest/mocker": "3.2.2",
+				"@vitest/pretty-format": "^3.2.2",
+				"@vitest/runner": "3.2.2",
+				"@vitest/snapshot": "3.2.2",
+				"@vitest/spy": "3.2.2",
+				"@vitest/utils": "3.2.2",
+				"chai": "^5.2.0",
+				"debug": "^4.4.1",
+				"expect-type": "^1.2.1",
+				"magic-string": "^0.30.17",
+				"pathe": "^2.0.3",
+				"picomatch": "^4.0.2",
+				"std-env": "^3.9.0",
+				"tinybench": "^2.9.0",
+				"tinyexec": "^0.3.2",
+				"tinyglobby": "^0.2.14",
+				"tinypool": "^1.1.0",
+				"tinyrainbow": "^2.0.0",
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+				"vite-node": "3.2.2",
+				"why-is-node-running": "^2.3.0"
+			},
+			"bin": {
+				"vitest": "vitest.mjs"
+			},
+			"engines": {
+				"node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			},
+			"peerDependencies": {
+				"@edge-runtime/vm": "*",
+				"@types/debug": "^4.1.12",
+				"@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+				"@vitest/browser": "3.2.2",
+				"@vitest/ui": "3.2.2",
+				"happy-dom": "*",
+				"jsdom": "*"
+			},
+			"peerDependenciesMeta": {
+				"@edge-runtime/vm": {
+					"optional": true
+				},
+				"@types/debug": {
+					"optional": true
+				},
+				"@types/node": {
+					"optional": true
+				},
+				"@vitest/browser": {
+					"optional": true
+				},
+				"@vitest/ui": {
+					"optional": true
+				},
+				"happy-dom": {
+					"optional": true
+				},
+				"jsdom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/why-is-node-running": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+			"integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"siginfo": "^2.0.0",
+				"stackback": "0.0.2"
+			},
+			"bin": {
+				"why-is-node-running": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
 		"esbuild": "0.25.5",
-		"typescript": "^5.8.3"
+		"oracledb": "^6.8.0",
+		"typescript": "^5.8.3",
+		"vitest": "^3.2.2"
 	},
 	"dependencies": {
 		"@types/mle-js": "github:oracle-samples/mle-modules#main"

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ As part of the database initialisation you get a new user account in `freepdb1`,
 
 All scripts are to be run as `demouser` on `freepdb1`; ideally using VSCode and [SQLDeveloper Extension for VSCode](https://marketplace.visualstudio.com/items?itemName=Oracle.sql-developer)
 
+### Basic Examples
+
 You'll find **basic examples** in `02_basic_examples`:
 
 - [Inline JavaScript](https://docs.oracle.com/en/database/oracle/oracle-database/23/mlejs/call-specifications-functions.html) functions and procedures
@@ -48,7 +50,15 @@ You'll find **basic examples** in `02_basic_examples`:
 - Examples how to expose JavaScript to SQL and PL/SQL
 - Dynamic JavaScript execution
 
+### Typescript
+
 You can find more advanced examples how to write, test, and transpile **Typescript** to In-Database JavaScript in `03_typescript`.
+
+They can be transpiled to JavaScript and loaded into the database using `03_typescript/utils/deploy.sh`. You need to change directory to `03_typescript` before executing the deployment script. Once the transpiled code has been loaded you can view it in the schema browser.
+
+You should also take a moment to review the code completion features and type mappings in the `index.ts` file.
+
+### NoSQL aka SODA
 
 The final set of examples concerns the **NoSQL-style API** named [SODA](https://docs.oracle.com/en/database/oracle/oracle-database/23/mlejs/soda-collections-in-mle-js.html). Simple Oracle Document Access (SODA) is a set of NoSQL-style APIs that let you create and store collections of documents (in particular JSON) in Oracle Database, retrieve them, and query them, without needing to know Structured Query Language (SQL) or how the documents are stored in the database.
 


### PR DESCRIPTION
Typescript is a superset of JavaScript and allows for strict type checking and helps developers avoid runtime errors.

This PR adds

- a Typescript example
- unit testing using vitest
- a utility script to 

Real projects using Typescript in combination with MLE/JavaScript can use a similar approach to transpile Typescript to JavaScript, and optionally bundle code, before loading it into the database. From that point on, SQLcl projects should be used for an end-to-end CI/CD workflow. 