### PR TITLE
feat: bump image tag to 23.8 to address issue 5

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   oracle:
-    image: container-registry.oracle.com/database/free:23.8.0.0-amd64
+    image: container-registry.oracle.com/database/free:23.8.0.0
     ports:
       - 1521:1521
     environment:


### PR DESCRIPTION
fix #5 by changing the image tag to the generic one after the release of the Arm image