### PR TITLE
Update Oracle DB Free image to 23.9.0.0 in compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   oracle:
-    image: container-registry.oracle.com/database/free:23.8.0.0
+    image: container-registry.oracle.com/database/free:23.9.0.0
     ports:
       - 1521:1521
     environment:


### PR DESCRIPTION
Bump from 23.8.0.0 to 23.9.0.0 to pick up the latest bug fixes and security updates and keep the stack aligned with upstream.